### PR TITLE
feat: add Size function to PublicKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Forked from https://github.com/spacemonkeygo/openssl (unmaintained) to add:
 
 1. FreeBSD support.
 2. Key equality checking.
+3. A function to get the size of signatures produced by a key.
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -4,3 +4,5 @@ require (
 	github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572
 	golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb // indirect
 )
+
+go 1.12

--- a/key.go
+++ b/key.go
@@ -88,6 +88,9 @@ type PublicKey interface {
 	// Equal compares the key with the passed in key.
 	Equal(key PublicKey) bool
 
+	// Size returns the size (in bytes) of signatures created with this key.
+	Size() int
+
 	evpPKey() *C.EVP_PKEY
 }
 
@@ -118,6 +121,10 @@ func (key *pKey) Equal(other PublicKey) bool {
 
 func (key *pKey) KeyType() NID {
 	return NID(C.EVP_PKEY_id(key.key))
+}
+
+func (key *pKey) Size() int {
+	return int(C.EVP_PKEY_size(key.key))
 }
 
 func (key *pKey) BaseType() NID {


### PR DESCRIPTION
This allows us to determine the size of signatures produced by a public key.
Incidentally, this also allows us to determine the size of an RSA key's modulus.