### PR TITLE
pass build flags on Solaris/Illumos

### DIFF
--- a/build.go
+++ b/build.go
@@ -16,8 +16,8 @@
 
 package openssl
 
-// #cgo linux windows freebsd openbsd pkg-config: libssl libcrypto
-// #cgo linux freebsd openbsd CFLAGS: -Wno-deprecated-declarations
+// #cgo linux windows freebsd openbsd solaris pkg-config: libssl libcrypto
+// #cgo linux freebsd openbsd solaris CFLAGS: -Wno-deprecated-declarations
 // #cgo darwin CFLAGS: -I/usr/local/opt/openssl@1.1/include -I/usr/local/opt/openssl/include -Wno-deprecated-declarations
 // #cgo darwin LDFLAGS: -L/usr/local/opt/openssl@1.1/lib -L/usr/local/opt/openssl/lib -lssl -lcrypto
 // #cgo windows CFLAGS: -DWIN32_LEAN_AND_MEAN

--- a/build_static.go
+++ b/build_static.go
@@ -16,8 +16,8 @@
 
 package openssl
 
-// #cgo linux windows freebsd openbsd pkg-config: --static libssl libcrypto
-// #cgo linux freebsd openbsd CFLAGS: -Wno-deprecated-declarations
+// #cgo linux windows freebsd openbsd solaris pkg-config: --static libssl libcrypto
+// #cgo linux freebsd openbsd solaris CFLAGS: -Wno-deprecated-declarations
 // #cgo darwin CFLAGS: -I/usr/local/opt/openssl@1.1/include -I/usr/local/opt/openssl/include -Wno-deprecated-declarations
 // #cgo darwin LDFLAGS: -L/usr/local/opt/openssl@1.1/lib -L/usr/local/opt/openssl/lib -lssl -lcrypto
 // #cgo windows CFLAGS: -DWIN32_LEAN_AND_MEAN


### PR DESCRIPTION
Following: https://github.com/libp2p/go-openssl/pull/2
Without this, I couldn't build go-ipfs on llumos with the `openssl` Go tag.
```
# github.com/libp2p/go-openssl
Undefined			first referenced
 symbol  			    in file
X509_check_email                    $WORK/b142/_x015.o
(...log truncated...)
ENGINE_by_id                        $WORK/b142/_x012.o
ld: fatal: symbol referencing errors. No output written to $WORK/b142/_cgo_.o
collect2: error: ld returned 1 exit status
```
With it, the build succeeds and `ldd ipfs` sees `libssl.so.1.0.0 => /lib/64/libssl.so.1.0.0`.

Test machine:
```
uname -osvr
SunOS 5.11 illumos-10b633f40f illumos
```