### PR TITLE
add binding for OBJ_create

### DIFF
--- a/object.go
+++ b/object.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2017. See AUTHORS.
+// Copyright (C) 2020. See AUTHORS.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/object.go
+++ b/object.go
@@ -1,0 +1,24 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+// #include "shim.h"
+import "C"
+
+// CreateObjectIdentifier creates ObjectIdentifier and returns NID for the created
+// ObjectIdentifier
+func CreateObjectIdentifier(oid string, shortName string, longName string) int {
+	return int(C.OBJ_create(C.CString(oid), C.CString(shortName), C.CString(longName)))
+}

--- a/shim.h
+++ b/shim.h
@@ -29,6 +29,7 @@
 #include <openssl/x509v3.h>
 #include <openssl/ec.h>
 
+
 #ifndef SSL_MODE_RELEASE_BUFFERS
 #define SSL_MODE_RELEASE_BUFFERS 0
 #endif
@@ -170,3 +171,6 @@ extern int X_X509_set_version(X509 *x, long version);
 
 /* PEM methods */
 extern int X_PEM_write_bio_PrivateKey_traditional(BIO *bio, EVP_PKEY *key, const EVP_CIPHER *enc, unsigned char *kstr, int klen, pem_password_cb *cb, void *u);
+
+/* Object methods */
+extern int OBJ_create(const char *oid,const char *sn,const char *ln);


### PR DESCRIPTION
Motivation: In order to add an extension to the certificate, we need nid in OpenSSL. 

This patch allows adding custom oid. 

Related to https://github.com/libp2p/go-libp2p-tls/issues/55
Signed-off-by: Tiger <rbalajis25@gmail.com>