### PR TITLE
Added basic support for TLS 1.3 using openssl min/max proto version functions

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -95,7 +95,7 @@ func NewCtxWithVersion(version SSLVersion) (*Ctx, error) {
 	case TLSv1_2:
 		method = C.X_TLSv1_2_method()
 	case AnyVersion:
-		method = C.X_SSLv23_method()
+		method = C.X_TLS_method()
 	}
 	if method == nil {
 		return nil, errors.New("unknown ssl/tls version")
@@ -359,6 +359,36 @@ func (c *Ctx) LoadVerifyLocations(ca_file string, ca_path string) error {
 		return errorFromErrorQueue()
 	}
 	return nil
+}
+
+type Version int
+
+const (
+	SSL3_VERSION Version = C.SSL3_VERSION
+	TLS1_VERSION Version = C.TLS1_VERSION
+	TLS1_1_VERSION Version = C.TLS1_1_VERSION
+	TLS1_2_VERSION Version = C.TLS1_2_VERSION
+	TLS1_3_VERSION Version = C.TLS1_3_VERSION
+	DTLS1_VERSION Version = C.DTLS1_VERSION
+	DTLS1_2_VERSION Version = C.DTLS1_2_VERSION
+)
+
+func (c *Ctx) SetMinProtoVersion(version Version) bool {
+	return C.X_SSL_CTX_set_min_proto_version(
+		c.ctx, C.int(version)) == 1
+}
+
+func (c *Ctx) SetMaxProtoVersion(version Version) bool {
+	return C.X_SSL_CTX_set_max_proto_version(
+		c.ctx, C.int(version)) == 1
+}
+
+func (c *Ctx) GetMinProtoVersion() Version {
+	return Version(C.X_SSL_CTX_get_min_proto_version(c.ctx))
+}
+
+func (c *Ctx) GetMaxProtoVersion() Version {
+	return Version(C.X_SSL_CTX_get_max_proto_version(c.ctx))
 }
 
 type Options int

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -46,3 +46,28 @@ func TestCtxSessCacheSizeOption(t *testing.T) {
 		t.Error("SessSetCacheSize() does not save anything to ctx")
 	}
 }
+
+func TestCtxMinProtoVersion(t *testing.T) {
+	ctx, _ := NewCtx()
+	set_success := ctx.SetMinProtoVersion(TLS1_3_VERSION)
+	if !set_success {
+		t.Error("SetMinProtoVersion() does not return true")
+	}
+	get_version := ctx.GetMinProtoVersion()
+	if (get_version & TLS1_3_VERSION) != TLS1_3_VERSION {
+		t.Error("GetMinProtoVersion() does not return TLS1_3_VERSION")
+	}
+}
+
+func TestCtxMaxProtoVersion(t *testing.T) {
+	ctx, _ := NewCtx()
+	set_success := ctx.SetMaxProtoVersion(TLS1_3_VERSION)
+	if !set_success {
+		t.Error("SetMaxProtoVersion() does not return true")
+	}
+	get_version := ctx.GetMaxProtoVersion()
+	if (get_version & TLS1_3_VERSION) != TLS1_3_VERSION {
+		t.Error("GetMaxProtoVersion() does not return TLS1_3_VERSION")
+	}
+}
+

--- a/shim.c
+++ b/shim.c
@@ -471,8 +471,28 @@ const SSL_METHOD *X_TLSv1_2_method() {
 #endif
 }
 
+const SSL_METHOD *X_TLS_method() {
+	return TLS_method();
+}
+
 int X_SSL_CTX_new_index() {
 	return SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
+}
+
+int X_SSL_CTX_set_min_proto_version(SSL_CTX *ctx, int version) {
+	return SSL_CTX_set_min_proto_version(ctx, version);
+}
+
+int X_SSL_CTX_set_max_proto_version(SSL_CTX *ctx, int version) {
+	return SSL_CTX_set_max_proto_version(ctx, version);
+}
+
+int X_SSL_CTX_get_min_proto_version(SSL_CTX *ctx) {
+	return SSL_CTX_get_min_proto_version(ctx);
+}
+
+int X_SSL_CTX_get_max_proto_version(SSL_CTX *ctx) {
+	return SSL_CTX_get_max_proto_version(ctx);
 }
 
 long X_SSL_CTX_set_options(SSL_CTX* ctx, long options) {

--- a/shim.h
+++ b/shim.h
@@ -59,6 +59,7 @@ extern const SSL_METHOD *X_SSLv3_method();
 extern const SSL_METHOD *X_TLSv1_method();
 extern const SSL_METHOD *X_TLSv1_1_method();
 extern const SSL_METHOD *X_TLSv1_2_method();
+extern const SSL_METHOD *X_TLS_method();
 
 #if defined SSL_CTRL_SET_TLSEXT_HOSTNAME
 extern int sni_cb(SSL *ssl_conn, int *ad, void *arg);
@@ -92,6 +93,10 @@ extern int X_SSL_CTX_ticket_key_cb(SSL *s, unsigned char key_name[16],
         EVP_CIPHER_CTX *cctx, HMAC_CTX *hctx, int enc);
 extern int SSL_CTX_set_alpn_protos(SSL_CTX *ctx, const unsigned char *protos,
                              unsigned int protos_len);
+extern int X_SSL_CTX_set_min_proto_version(SSL_CTX *ctx, int version);
+extern int X_SSL_CTX_set_max_proto_version(SSL_CTX *ctx, int version);
+extern int X_SSL_CTX_get_min_proto_version(SSL_CTX *ctx);
+extern int X_SSL_CTX_get_max_proto_version(SSL_CTX *ctx);
 
 /* BIO methods */
 extern int X_BIO_get_flags(BIO *b);


### PR DESCRIPTION
Closes: #8 

Required for: libp2p/go-libp2p-tls#67, ipfs/go-ipfs#7150