### PR TITLE
Address `staticcheck` issues

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -267,8 +267,8 @@ func (c *Certificate) Sign(privKey PrivateKey, digest EVP_MD) error {
 	case EVP_SHA384:
 	case EVP_SHA512:
 	default:
-		return errors.New("Unsupported digest" +
-			"You're probably looking for 'EVP_SHA256' or 'EVP_SHA512'.")
+		return errors.New("unsupported digest; " +
+			"you're probably looking for 'EVP_SHA256' or 'EVP_SHA512'")
 	}
 	return c.insecureSign(privKey, digest)
 }
@@ -336,7 +336,7 @@ func (c *Certificate) AddCustomExtension(nid NID, value []byte) error {
 	val := (*C.char)(C.CBytes(value))
 	defer C.free(unsafe.Pointer(val))
 	if int(C.add_custom_ext(c.x, C.int(nid), val, C.int(len(value)))) == 0 {
-		return errors.New("Unable to add extension")
+		return errors.New("unable to add extension")
 	}
 	return nil
 }

--- a/ciphers.go
+++ b/ciphers.go
@@ -125,7 +125,7 @@ func (ctx *cipherCtx) applyKeyAndIV(key, iv []byte) error {
 		} else {
 			res = C.EVP_DecryptInit_ex(ctx.ctx, nil, nil, kptr, iptr)
 		}
-		if 1 != res {
+		if res != 1 {
 			return errors.New("failed to apply key/IV")
 		}
 	}
@@ -243,7 +243,7 @@ func newEncryptionCipherCtx(c *Cipher, e *Engine, key, iv []byte) (
 	if e != nil {
 		eptr = e.e
 	}
-	if 1 != C.EVP_EncryptInit_ex(ctx.ctx, c.ptr, eptr, nil, nil) {
+	if C.EVP_EncryptInit_ex(ctx.ctx, c.ptr, eptr, nil, nil) != 1 {
 		return nil, errors.New("failed to initialize cipher context")
 	}
 	err = ctx.applyKeyAndIV(key, iv)
@@ -266,7 +266,7 @@ func newDecryptionCipherCtx(c *Cipher, e *Engine, key, iv []byte) (
 	if e != nil {
 		eptr = e.e
 	}
-	if 1 != C.EVP_DecryptInit_ex(ctx.ctx, c.ptr, eptr, nil, nil) {
+	if C.EVP_DecryptInit_ex(ctx.ctx, c.ptr, eptr, nil, nil) != 1 {
 		return nil, errors.New("failed to initialize cipher context")
 	}
 	err = ctx.applyKeyAndIV(key, iv)
@@ -317,7 +317,7 @@ func (ctx *decryptionCipherCtx) DecryptUpdate(input []byte) ([]byte, error) {
 func (ctx *encryptionCipherCtx) EncryptFinal() ([]byte, error) {
 	outbuf := make([]byte, ctx.BlockSize())
 	var outlen C.int
-	if 1 != C.EVP_EncryptFinal_ex(ctx.ctx, (*C.uchar)(&outbuf[0]), &outlen) {
+	if C.EVP_EncryptFinal_ex(ctx.ctx, (*C.uchar)(&outbuf[0]), &outlen) != 1 {
 		return nil, errors.New("encryption failed")
 	}
 	return outbuf[:outlen], nil
@@ -326,7 +326,7 @@ func (ctx *encryptionCipherCtx) EncryptFinal() ([]byte, error) {
 func (ctx *decryptionCipherCtx) DecryptFinal() ([]byte, error) {
 	outbuf := make([]byte, ctx.BlockSize())
 	var outlen C.int
-	if 1 != C.EVP_DecryptFinal_ex(ctx.ctx, (*C.uchar)(&outbuf[0]), &outlen) {
+	if C.EVP_DecryptFinal_ex(ctx.ctx, (*C.uchar)(&outbuf[0]), &outlen) != 1 {
 		// this may mean the tag failed to verify- all previous plaintext
 		// returned must be considered faked and invalid
 		return nil, errors.New("decryption failed")

--- a/ciphers_gcm.go
+++ b/ciphers_gcm.go
@@ -86,8 +86,8 @@ func NewGCMEncryptionCipherCtx(blocksize int, e *Engine, key, iv []byte) (
 			return nil, fmt.Errorf("could not set IV len to %d: %s",
 				len(iv), err)
 		}
-		if 1 != C.EVP_EncryptInit_ex(ctx.ctx, nil, nil, nil,
-			(*C.uchar)(&iv[0])) {
+		if C.EVP_EncryptInit_ex(ctx.ctx, nil, nil, nil,
+			(*C.uchar)(&iv[0])) != 1 {
 			return nil, errors.New("failed to apply IV")
 		}
 	}
@@ -110,8 +110,8 @@ func NewGCMDecryptionCipherCtx(blocksize int, e *Engine, key, iv []byte) (
 			return nil, fmt.Errorf("could not set IV len to %d: %s",
 				len(iv), err)
 		}
-		if 1 != C.EVP_DecryptInit_ex(ctx.ctx, nil, nil, nil,
-			(*C.uchar)(&iv[0])) {
+		if C.EVP_DecryptInit_ex(ctx.ctx, nil, nil, nil,
+			(*C.uchar)(&iv[0])) != 1 {
 			return nil, errors.New("failed to apply IV")
 		}
 	}
@@ -123,8 +123,8 @@ func (ctx *authEncryptionCipherCtx) ExtraData(aad []byte) error {
 		return nil
 	}
 	var outlen C.int
-	if 1 != C.EVP_EncryptUpdate(ctx.ctx, nil, &outlen, (*C.uchar)(&aad[0]),
-		C.int(len(aad))) {
+	if C.EVP_EncryptUpdate(ctx.ctx, nil, &outlen, (*C.uchar)(&aad[0]),
+		C.int(len(aad))) != 1 {
 		return errors.New("failed to add additional authenticated data")
 	}
 	return nil
@@ -135,8 +135,8 @@ func (ctx *authDecryptionCipherCtx) ExtraData(aad []byte) error {
 		return nil
 	}
 	var outlen C.int
-	if 1 != C.EVP_DecryptUpdate(ctx.ctx, nil, &outlen, (*C.uchar)(&aad[0]),
-		C.int(len(aad))) {
+	if C.EVP_DecryptUpdate(ctx.ctx, nil, &outlen, (*C.uchar)(&aad[0]),
+		C.int(len(aad))) != 1 {
 		return errors.New("failed to add additional authenticated data")
 	}
 	return nil

--- a/ciphers_test.go
+++ b/ciphers_test.go
@@ -185,17 +185,16 @@ func TestBadTag(t *testing.T) {
 	}
 	// flip the last bit
 	tag[len(tag)-1] ^= 1
-	plaintext_out, err := doDecryption(key, iv, nil, ciphertext, tag, 128, 129)
-	if err == nil {
+	if _, err := doDecryption(key, iv, nil, ciphertext, tag, 128, 129); err == nil {
 		t.Fatal("Expected error for bad tag, but got none")
 	}
 	// flip it back, try again just to make sure
 	tag[len(tag)-1] ^= 1
-	plaintext_out, err = doDecryption(key, iv, nil, ciphertext, tag, 128, 129)
+	plaintextOut, err := doDecryption(key, iv, nil, ciphertext, tag, 128, 129)
 	if err != nil {
 		t.Fatal("Decryption failure:", err)
 	}
-	checkEqual(t, plaintext_out, plaintext)
+	checkEqual(t, plaintextOut, plaintext)
 }
 
 func TestBadCiphertext(t *testing.T) {
@@ -211,17 +210,16 @@ func TestBadCiphertext(t *testing.T) {
 	}
 	// flip the last bit
 	ciphertext[len(ciphertext)-1] ^= 1
-	plaintext_out, err := doDecryption(key, iv, aad, ciphertext, tag, 192, 192)
-	if err == nil {
+	if _, err := doDecryption(key, iv, aad, ciphertext, tag, 192, 192); err == nil {
 		t.Fatal("Expected error for bad ciphertext, but got none")
 	}
 	// flip it back, try again just to make sure
 	ciphertext[len(ciphertext)-1] ^= 1
-	plaintext_out, err = doDecryption(key, iv, aad, ciphertext, tag, 192, 192)
+	plaintextOut, err := doDecryption(key, iv, aad, ciphertext, tag, 192, 192)
 	if err != nil {
 		t.Fatal("Decryption failure:", err)
 	}
-	checkEqual(t, plaintext_out, plaintext)
+	checkEqual(t, plaintextOut, plaintext)
 }
 
 func TestBadAAD(t *testing.T) {
@@ -237,17 +235,16 @@ func TestBadAAD(t *testing.T) {
 	}
 	// flip the last bit
 	aad[len(aad)-1] ^= 1
-	plaintext_out, err := doDecryption(key, iv, aad, ciphertext, tag, 256, 256)
-	if err == nil {
+	if _, err := doDecryption(key, iv, aad, ciphertext, tag, 256, 256); err == nil {
 		t.Fatal("Expected error for bad AAD, but got none")
 	}
 	// flip it back, try again just to make sure
 	aad[len(aad)-1] ^= 1
-	plaintext_out, err = doDecryption(key, iv, aad, ciphertext, tag, 256, 256)
+	plaintextOut, err := doDecryption(key, iv, aad, ciphertext, tag, 256, 256)
 	if err != nil {
 		t.Fatal("Decryption failure:", err)
 	}
-	checkEqual(t, plaintext_out, plaintext)
+	checkEqual(t, plaintextOut, plaintext)
 }
 
 func TestNonAuthenticatedEncryption(t *testing.T) {

--- a/conn.go
+++ b/conn.go
@@ -31,10 +31,10 @@ import (
 )
 
 var (
-	zeroReturn = errors.New("zero return")
-	wantRead   = errors.New("want read")
-	wantWrite  = errors.New("want write")
-	tryAgain   = errors.New("try again")
+	errZeroReturn = errors.New("zero return")
+	errWantRead   = errors.New("want read")
+	errWantWrite  = errors.New("want write")
+	errTryAgain   = errors.New("try again")
 )
 
 type Conn struct {
@@ -192,7 +192,7 @@ func (c *Conn) GetCtx() *Ctx { return c.ctx }
 func (c *Conn) CurrentCipher() (string, error) {
 	p := C.X_SSL_get_cipher_name(c.ssl)
 	if p == nil {
-		return "", errors.New("Session not established")
+		return "", errors.New("session not established")
 	}
 
 	return C.GoString(p), nil
@@ -247,7 +247,7 @@ func (c *Conn) getErrorHandler(rv C.int, errno error) func() error {
 			if err != nil {
 				return err
 			}
-			return tryAgain
+			return errTryAgain
 		}
 	case C.SSL_ERROR_WANT_WRITE:
 		return func() error {
@@ -255,7 +255,7 @@ func (c *Conn) getErrorHandler(rv C.int, errno error) func() error {
 			if err != nil {
 				return err
 			}
-			return tryAgain
+			return errTryAgain
 		}
 	case C.SSL_ERROR_SYSCALL:
 		var err error
@@ -303,8 +303,8 @@ func (c *Conn) handshake() func() error {
 // Handshake performs an SSL handshake. If a handshake is not manually
 // triggered, it will run before the first I/O on the encrypted stream.
 func (c *Conn) Handshake() error {
-	err := tryAgain
-	for err == tryAgain {
+	err := errTryAgain
+	for err == errTryAgain {
 		err = c.handleError(c.handshake())
 	}
 	go c.flushOutputBuffer()
@@ -404,15 +404,15 @@ func (c *Conn) shutdown() func() error {
 }
 
 func (c *Conn) shutdownLoop() error {
-	err := tryAgain
+	err := errTryAgain
 	shutdown_tries := 0
-	for err == tryAgain {
+	for err == errTryAgain {
 		shutdown_tries = shutdown_tries + 1
 		err = c.handleError(c.shutdown())
 		if err == nil {
 			return c.flushOutputBuffer()
 		}
-		if err == tryAgain && shutdown_tries >= 2 {
+		if err == errTryAgain && shutdown_tries >= 2 {
 			return errors.New("shutdown requested a third time?")
 		}
 	}
@@ -463,8 +463,8 @@ func (c *Conn) Read(b []byte) (n int, err error) {
 	if len(b) == 0 {
 		return 0, nil
 	}
-	err = tryAgain
-	for err == tryAgain {
+	err = errTryAgain
+	for err == errTryAgain {
 		n, errcb := c.read(b)
 		err = c.handleError(errcb)
 		if err == nil {
@@ -504,8 +504,8 @@ func (c *Conn) Write(b []byte) (written int, err error) {
 	if len(b) == 0 {
 		return 0, nil
 	}
-	err = tryAgain
-	for err == tryAgain {
+	err = errTryAgain
+	for err == errTryAgain {
 		n, errcb := c.write(b)
 		err = c.handleError(errcb)
 		if err == nil {

--- a/ctx.go
+++ b/ctx.go
@@ -127,7 +127,7 @@ func NewCtxFromFiles(cert_file string, key_file string) (*Ctx, error) {
 
 	certs := SplitPEM(cert_bytes)
 	if len(certs) == 0 {
-		return nil, fmt.Errorf("No PEM certificate found in '%s'", cert_file)
+		return nil, fmt.Errorf("no PEM certificate found in '%s'", cert_file)
 	}
 	first, certs := certs[0], certs[1:]
 	cert, err := LoadCertificateFromPEM(first)
@@ -190,7 +190,7 @@ func (c *Ctx) SetEllipticCurve(curve EllipticCurve) error {
 
 	k := C.EC_KEY_new_by_curve_name(C.int(curve))
 	if k == nil {
-		return errors.New("Unknown curve")
+		return errors.New("unknown curve")
 	}
 	defer C.EC_KEY_free(k)
 
@@ -302,12 +302,12 @@ type CertificateStoreCtx struct {
 	ssl_ctx *Ctx
 }
 
-func (self *CertificateStoreCtx) VerifyResult() VerifyResult {
-	return VerifyResult(C.X509_STORE_CTX_get_error(self.ctx))
+func (csc *CertificateStoreCtx) VerifyResult() VerifyResult {
+	return VerifyResult(C.X509_STORE_CTX_get_error(csc.ctx))
 }
 
-func (self *CertificateStoreCtx) Err() error {
-	code := C.X509_STORE_CTX_get_error(self.ctx)
+func (csc *CertificateStoreCtx) Err() error {
+	code := C.X509_STORE_CTX_get_error(csc.ctx)
 	if code == C.X509_V_OK {
 		return nil
 	}
@@ -315,19 +315,19 @@ func (self *CertificateStoreCtx) Err() error {
 		C.GoString(C.X509_verify_cert_error_string(C.long(code))))
 }
 
-func (self *CertificateStoreCtx) Depth() int {
-	return int(C.X509_STORE_CTX_get_error_depth(self.ctx))
+func (csc *CertificateStoreCtx) Depth() int {
+	return int(C.X509_STORE_CTX_get_error_depth(csc.ctx))
 }
 
-// the certicate returned is only valid for the lifetime of the underlying
+// the certificate returned is only valid for the lifetime of the underlying
 // X509_STORE_CTX
-func (self *CertificateStoreCtx) GetCurrentCert() *Certificate {
-	x509 := C.X509_STORE_CTX_get_current_cert(self.ctx)
+func (csc *CertificateStoreCtx) GetCurrentCert() *Certificate {
+	x509 := C.X509_STORE_CTX_get_current_cert(csc.ctx)
 	if x509 == nil {
 		return nil
 	}
 	// add a ref
-	if 1 != C.X_X509_add_ref(x509) {
+	if C.X_X509_add_ref(x509) != 1 {
 		return nil
 	}
 	cert := &Certificate{
@@ -531,7 +531,7 @@ func (c *Ctx) SetNextProtos(protos []string) error {
 	for _, proto := range protos {
 		if len(proto) > 255 {
 			return fmt.Errorf(
-				"Proto length can't be more than 255. But got a proto %s with length %d",
+				"proto length can't be more than 255. But got a proto %s with length %d",
 				proto, len(proto))
 		}
 		vector = append(vector, byte(uint8(len(proto))))
@@ -540,7 +540,7 @@ func (c *Ctx) SetNextProtos(protos []string) error {
 	ret := int(C.SSL_CTX_set_alpn_protos(c.ctx, (*C.uchar)(unsafe.Pointer(&vector[0])),
 		C.uint(len(vector))))
 	if ret != 0 {
-		return errors.New("Error while setting protos to ctx")
+		return errors.New("error while setting protos to ctx")
 	}
 	return nil
 }

--- a/dh_test.go
+++ b/dh_test.go
@@ -40,7 +40,7 @@ func TestECDH(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if bytes.Compare(mySecret, theirSecret) != 0 {
+	if !bytes.Equal(mySecret, theirSecret) {
 		t.Fatal("shared secrets are different")
 	}
 }

--- a/hmac.go
+++ b/hmac.go
@@ -74,7 +74,7 @@ func (h *HMAC) Write(data []byte) (n int, err error) {
 }
 
 func (h *HMAC) Reset() error {
-	if 1 != C.X_HMAC_Init_ex(h.ctx, nil, 0, nil, nil) {
+	if C.X_HMAC_Init_ex(h.ctx, nil, 0, nil, nil) != 1 {
 		return errors.New("failed to reset HMAC_CTX")
 	}
 	return nil

--- a/hostname.go
+++ b/hostname.go
@@ -40,7 +40,7 @@ import (
 )
 
 var (
-	ValidationError = errors.New("Host validation error")
+	ValidationError = errors.New("host validation error") //lint:ignore ST1012 rename may cause breaking changes; research before renaming.
 )
 
 type CheckFlags int

--- a/init.go
+++ b/init.go
@@ -88,14 +88,13 @@ package openssl
 import "C"
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 )
 
 func init() {
 	if rc := C.X_shim_init(); rc != 0 {
-		panic(fmt.Errorf("X_shim_init failed with %d", rc))
+		panic(fmt.Errorf("x_shim_init failed with %d", rc))
 	}
 }
 
@@ -113,5 +112,5 @@ func errorFromErrorQueue() error {
 			C.GoString(C.ERR_func_error_string(err)),
 			C.GoString(C.ERR_reason_error_string(err))))
 	}
-	return errors.New(fmt.Sprintf("SSL errors: %s", strings.Join(errs, "\n")))
+	return fmt.Errorf("SSL errors: %s", strings.Join(errs, "\n"))
 }

--- a/key.go
+++ b/key.go
@@ -143,36 +143,36 @@ func (key *pKey) SignPKCS1v15(method Method, data []byte) ([]byte, error) {
 			return nil, errors.New("signpkcs1v15: 0-length data or non-null digest")
 		}
 
-		if 1 != C.X_EVP_DigestSignInit(ctx, nil, nil, nil, key.key) {
+		if C.X_EVP_DigestSignInit(ctx, nil, nil, nil, key.key) != 1 {
 			return nil, errors.New("signpkcs1v15: failed to init signature")
 		}
 
 		// evp signatures are 64 bytes
-		sig := make([]byte, 64, 64)
+		sig := make([]byte, 64)
 		var sigblen C.size_t = 64
-		if 1 != C.X_EVP_DigestSign(ctx,
-			((*C.uchar)(unsafe.Pointer(&sig[0]))),
+		if C.X_EVP_DigestSign(ctx,
+			(*C.uchar)(unsafe.Pointer(&sig[0])),
 			&sigblen,
 			(*C.uchar)(unsafe.Pointer(&data[0])),
-			C.size_t(len(data))) {
+			C.size_t(len(data))) != 1 {
 			return nil, errors.New("signpkcs1v15: failed to do one-shot signature")
 		}
 
 		return sig[:sigblen], nil
 	} else {
-		if 1 != C.X_EVP_SignInit(ctx, method) {
+		if C.X_EVP_SignInit(ctx, method) != 1 {
 			return nil, errors.New("signpkcs1v15: failed to init signature")
 		}
 		if len(data) > 0 {
-			if 1 != C.X_EVP_SignUpdate(
-				ctx, unsafe.Pointer(&data[0]), C.uint(len(data))) {
+			if C.X_EVP_SignUpdate(
+				ctx, unsafe.Pointer(&data[0]), C.uint(len(data))) != 1 {
 				return nil, errors.New("signpkcs1v15: failed to update signature")
 			}
 		}
 		sig := make([]byte, C.X_EVP_PKEY_size(key.key))
 		var sigblen C.uint
-		if 1 != C.X_EVP_SignFinal(ctx,
-			((*C.uchar)(unsafe.Pointer(&sig[0]))), &sigblen, key.key) {
+		if C.X_EVP_SignFinal(ctx,
+			(*C.uchar)(unsafe.Pointer(&sig[0])), &sigblen, key.key) != 1 {
 			return nil, errors.New("signpkcs1v15: failed to finalize signature")
 		}
 		return sig[:sigblen], nil
@@ -194,32 +194,32 @@ func (key *pKey) VerifyPKCS1v15(method Method, data, sig []byte) error {
 			return errors.New("verifypkcs1v15: 0-length data or non-null digest")
 		}
 
-		if 1 != C.X_EVP_DigestVerifyInit(ctx, nil, nil, nil, key.key) {
+		if C.X_EVP_DigestVerifyInit(ctx, nil, nil, nil, key.key) != 1 {
 			return errors.New("verifypkcs1v15: failed to init verify")
 		}
 
-		if 1 != C.X_EVP_DigestVerify(ctx,
-			((*C.uchar)(unsafe.Pointer(&sig[0]))),
+		if C.X_EVP_DigestVerify(ctx,
+			(*C.uchar)(unsafe.Pointer(&sig[0])),
 			C.size_t(len(sig)),
 			(*C.uchar)(unsafe.Pointer(&data[0])),
-			C.size_t(len(data))) {
+			C.size_t(len(data))) != 1 {
 			return errors.New("verifypkcs1v15: failed to do one-shot verify")
 		}
 
 		return nil
 
 	} else {
-		if 1 != C.X_EVP_VerifyInit(ctx, method) {
+		if C.X_EVP_VerifyInit(ctx, method) != 1 {
 			return errors.New("verifypkcs1v15: failed to init verify")
 		}
 		if len(data) > 0 {
-			if 1 != C.X_EVP_VerifyUpdate(
-				ctx, unsafe.Pointer(&data[0]), C.uint(len(data))) {
+			if C.X_EVP_VerifyUpdate(
+				ctx, unsafe.Pointer(&data[0]), C.uint(len(data))) != 1 {
 				return errors.New("verifypkcs1v15: failed to update verify")
 			}
 		}
-		if 1 != C.X_EVP_VerifyFinal(ctx,
-			((*C.uchar)(unsafe.Pointer(&sig[0]))), C.uint(len(sig)), key.key) {
+		if C.X_EVP_VerifyFinal(ctx,
+			(*C.uchar)(unsafe.Pointer(&sig[0])), C.uint(len(sig)), key.key) != 1 {
 			return errors.New("verifypkcs1v15: failed to finalize verify")
 		}
 		return nil

--- a/key_test.go
+++ b/key_test.go
@@ -187,12 +187,10 @@ func TestGenerateEd25519(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = key.MarshalPKIXPublicKeyPEM()
-	if err != nil {
+	if _, err = key.MarshalPKIXPublicKeyPEM(); err != nil {
 		t.Fatal(err)
 	}
-	_, err = key.MarshalPKCS1PrivateKeyPEM()
-	if err != nil {
+	if _, err = key.MarshalPKCS1PrivateKeyPEM(); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -289,8 +287,7 @@ func TestSignED25519(t *testing.T) {
 }
 
 func TestMarshalEC(t *testing.T) {
-	key, err := LoadPrivateKeyFromPEM(prime256v1KeyBytes)
-	if err != nil {
+	if _, err := LoadPrivateKeyFromPEM(prime256v1KeyBytes); err != nil {
 		t.Fatal(err)
 	}
 	cert, err := LoadCertificateFromPEM(prime256v1CertBytes)
@@ -299,7 +296,7 @@ func TestMarshalEC(t *testing.T) {
 	}
 
 	privateBlock, _ := pem_pkg.Decode(prime256v1KeyBytes)
-	key, err = LoadPrivateKeyFromDER(privateBlock.Bytes)
+	key, err := LoadPrivateKeyFromDER(privateBlock.Bytes)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -410,8 +407,7 @@ func TestMarshalEd25519(t *testing.T) {
 		t.SkipNow()
 	}
 
-	key, err := LoadPrivateKeyFromPEM(ed25519KeyBytes)
-	if err != nil {
+	if _, err := LoadPrivateKeyFromPEM(ed25519KeyBytes); err != nil {
 		t.Fatal(err)
 	}
 	cert, err := LoadCertificateFromPEM(ed25519CertBytes)
@@ -420,7 +416,7 @@ func TestMarshalEd25519(t *testing.T) {
 	}
 
 	privateBlock, _ := pem_pkg.Decode(ed25519KeyBytes)
-	key, err = LoadPrivateKeyFromDER(privateBlock.Bytes)
+	key, err := LoadPrivateKeyFromDER(privateBlock.Bytes)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -435,17 +431,15 @@ func TestMarshalEd25519(t *testing.T) {
 		t.Fatal("invalid cert pem bytes")
 	}
 
-	pem, err = key.MarshalPKCS1PrivateKeyPEM()
-	if err != nil {
+	if _, err = key.MarshalPKCS1PrivateKeyPEM(); err != nil {
 		t.Fatal(err)
 	}
 
-	der, err := key.MarshalPKCS1PrivateKeyDER()
-	if err != nil {
+	if _, err := key.MarshalPKCS1PrivateKeyDER(); err != nil {
 		t.Fatal(err)
 	}
 
-	der, err = key.MarshalPKIXPublicKeyDER()
+	der, err := key.MarshalPKIXPublicKeyDER()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -455,22 +449,22 @@ func TestMarshalEd25519(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	loaded_pubkey_from_pem, err := LoadPublicKeyFromPEM(pem)
+	loadedPubkeyFromPem, err := LoadPublicKeyFromPEM(pem)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	loaded_pubkey_from_der, err := LoadPublicKeyFromDER(der)
+	loadedPubkeyFromDer, err := LoadPublicKeyFromDER(der)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = loaded_pubkey_from_pem.MarshalPKIXPublicKeyDER()
+	_, err = loadedPubkeyFromPem.MarshalPKIXPublicKeyDER()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = loaded_pubkey_from_der.MarshalPKIXPublicKeyDER()
+	_, err = loadedPubkeyFromDer.MarshalPKIXPublicKeyDER()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/md4.go
+++ b/md4.go
@@ -51,7 +51,7 @@ func (s *MD4Hash) Close() {
 }
 
 func (s *MD4Hash) Reset() error {
-	if 1 != C.X_EVP_DigestInit_ex(s.ctx, C.X_EVP_md4(), engineRef(s.engine)) {
+	if C.X_EVP_DigestInit_ex(s.ctx, C.X_EVP_md4(), engineRef(s.engine)) != 1 {
 		return errors.New("openssl: md4: cannot init digest ctx")
 	}
 	return nil
@@ -61,16 +61,16 @@ func (s *MD4Hash) Write(p []byte) (n int, err error) {
 	if len(p) == 0 {
 		return 0, nil
 	}
-	if 1 != C.X_EVP_DigestUpdate(s.ctx, unsafe.Pointer(&p[0]),
-		C.size_t(len(p))) {
+	if C.X_EVP_DigestUpdate(s.ctx, unsafe.Pointer(&p[0]),
+		C.size_t(len(p))) != 1 {
 		return 0, errors.New("openssl: md4: cannot update digest")
 	}
 	return len(p), nil
 }
 
 func (s *MD4Hash) Sum() (result [16]byte, err error) {
-	if 1 != C.X_EVP_DigestFinal_ex(s.ctx,
-		(*C.uchar)(unsafe.Pointer(&result[0])), nil) {
+	if C.X_EVP_DigestFinal_ex(s.ctx,
+		(*C.uchar)(unsafe.Pointer(&result[0])), nil) != 1 {
 		return result, errors.New("openssl: md4: cannot finalize ctx")
 	}
 	return result, s.Reset()

--- a/md5.go
+++ b/md5.go
@@ -51,7 +51,7 @@ func (s *MD5Hash) Close() {
 }
 
 func (s *MD5Hash) Reset() error {
-	if 1 != C.X_EVP_DigestInit_ex(s.ctx, C.X_EVP_md5(), engineRef(s.engine)) {
+	if C.X_EVP_DigestInit_ex(s.ctx, C.X_EVP_md5(), engineRef(s.engine)) != 1 {
 		return errors.New("openssl: md5: cannot init digest ctx")
 	}
 	return nil
@@ -61,16 +61,16 @@ func (s *MD5Hash) Write(p []byte) (n int, err error) {
 	if len(p) == 0 {
 		return 0, nil
 	}
-	if 1 != C.X_EVP_DigestUpdate(s.ctx, unsafe.Pointer(&p[0]),
-		C.size_t(len(p))) {
+	if C.X_EVP_DigestUpdate(s.ctx, unsafe.Pointer(&p[0]),
+		C.size_t(len(p))) != 1 {
 		return 0, errors.New("openssl: md5: cannot update digest")
 	}
 	return len(p), nil
 }
 
 func (s *MD5Hash) Sum() (result [16]byte, err error) {
-	if 1 != C.X_EVP_DigestFinal_ex(s.ctx,
-		(*C.uchar)(unsafe.Pointer(&result[0])), nil) {
+	if C.X_EVP_DigestFinal_ex(s.ctx,
+		(*C.uchar)(unsafe.Pointer(&result[0])), nil) != 1 {
 		return result, errors.New("openssl: md5: cannot finalize ctx")
 	}
 	return result, s.Reset()

--- a/pem.go
+++ b/pem.go
@@ -16,18 +16,13 @@ package openssl
 
 import (
 	"regexp"
-
 )
 
 var pemSplit *regexp.Regexp = regexp.MustCompile(`(?sm)` +
 	`(^-----[\s-]*?BEGIN.*?-----[\s-]*?$` +
 	`.*?` +
 	`^-----[\s-]*?END.*?-----[\s-]*?$)`)
-	
+
 func SplitPEM(data []byte) [][]byte {
-	var results [][]byte
-	for _, block := range pemSplit.FindAll(data, -1) {
-		results = append(results, block)
-	}
-	return results
+	return pemSplit.FindAll(data, -1)
 }

--- a/sha1.go
+++ b/sha1.go
@@ -58,7 +58,7 @@ func engineRef(e *Engine) *C.ENGINE {
 }
 
 func (s *SHA1Hash) Reset() error {
-	if 1 != C.X_EVP_DigestInit_ex(s.ctx, C.X_EVP_sha1(), engineRef(s.engine)) {
+	if C.X_EVP_DigestInit_ex(s.ctx, C.X_EVP_sha1(), engineRef(s.engine)) != 1 {
 		return errors.New("openssl: sha1: cannot init digest ctx")
 	}
 	return nil
@@ -68,16 +68,16 @@ func (s *SHA1Hash) Write(p []byte) (n int, err error) {
 	if len(p) == 0 {
 		return 0, nil
 	}
-	if 1 != C.X_EVP_DigestUpdate(s.ctx, unsafe.Pointer(&p[0]),
-		C.size_t(len(p))) {
+	if C.X_EVP_DigestUpdate(s.ctx, unsafe.Pointer(&p[0]),
+		C.size_t(len(p))) != 1 {
 		return 0, errors.New("openssl: sha1: cannot update digest")
 	}
 	return len(p), nil
 }
 
 func (s *SHA1Hash) Sum() (result [20]byte, err error) {
-	if 1 != C.X_EVP_DigestFinal_ex(s.ctx,
-		(*C.uchar)(unsafe.Pointer(&result[0])), nil) {
+	if C.X_EVP_DigestFinal_ex(s.ctx,
+		(*C.uchar)(unsafe.Pointer(&result[0])), nil) != 1 {
 		return result, errors.New("openssl: sha1: cannot finalize ctx")
 	}
 	return result, s.Reset()

--- a/sha256.go
+++ b/sha256.go
@@ -51,7 +51,7 @@ func (s *SHA256Hash) Close() {
 }
 
 func (s *SHA256Hash) Reset() error {
-	if 1 != C.X_EVP_DigestInit_ex(s.ctx, C.X_EVP_sha256(), engineRef(s.engine)) {
+	if C.X_EVP_DigestInit_ex(s.ctx, C.X_EVP_sha256(), engineRef(s.engine)) != 1 {
 		return errors.New("openssl: sha256: cannot init digest ctx")
 	}
 	return nil
@@ -61,16 +61,16 @@ func (s *SHA256Hash) Write(p []byte) (n int, err error) {
 	if len(p) == 0 {
 		return 0, nil
 	}
-	if 1 != C.X_EVP_DigestUpdate(s.ctx, unsafe.Pointer(&p[0]),
-		C.size_t(len(p))) {
+	if C.X_EVP_DigestUpdate(s.ctx, unsafe.Pointer(&p[0]),
+		C.size_t(len(p))) != 1 {
 		return 0, errors.New("openssl: sha256: cannot update digest")
 	}
 	return len(p), nil
 }
 
 func (s *SHA256Hash) Sum() (result [32]byte, err error) {
-	if 1 != C.X_EVP_DigestFinal_ex(s.ctx,
-		(*C.uchar)(unsafe.Pointer(&result[0])), nil) {
+	if C.X_EVP_DigestFinal_ex(s.ctx,
+		(*C.uchar)(unsafe.Pointer(&result[0])), nil) != 1 {
 		return result, errors.New("openssl: sha256: cannot finalize ctx")
 	}
 	return result, s.Reset()

--- a/utils/future.go
+++ b/utils/future.go
@@ -45,35 +45,35 @@ func NewFuture() *Future {
 }
 
 // Get blocks until the Future has a value set.
-func (self *Future) Get() (interface{}, error) {
-	self.mutex.Lock()
-	defer self.mutex.Unlock()
+func (f *Future) Get() (interface{}, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
 	for {
-		if self.received {
-			return self.val, self.err
+		if f.received {
+			return f.val, f.err
 		}
-		self.cond.Wait()
+		f.cond.Wait()
 	}
 }
 
 // Fired returns whether or not a value has been set. If Fired is true, Get
 // won't block.
-func (self *Future) Fired() bool {
-	self.mutex.Lock()
-	defer self.mutex.Unlock()
-	return self.received
+func (f *Future) Fired() bool {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+	return f.received
 }
 
 // Set provides the value to present and future Get calls. If Set has already
 // been called, this is a no-op.
-func (self *Future) Set(val interface{}, err error) {
-	self.mutex.Lock()
-	defer self.mutex.Unlock()
-	if self.received {
+func (f *Future) Set(val interface{}, err error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+	if f.received {
 		return
 	}
-	self.received = true
-	self.val = val
-	self.err = err
-	self.cond.Broadcast()
+	f.received = true
+	f.val = val
+	f.err = err
+	f.cond.Broadcast()
 }


### PR DESCRIPTION
Fix `staticcheck` issues:
- S1028 use `fmt.Errorf` to construct formatted errors
- ST1017 yoda conditions
- ST1005 error message capitalization
- ST1006 avoid `self` as receiver name
- S1030 use `buf.String`
- S1011 avoid redundant loop when `append` suffices
- SA4006 unused value
- S1019 remove redundant capacity on `make` call
- SA2002 `t.Fatal` called outside of test

Exported error violates ST1012, which is ignored by this PR since rename may cause breaking changes.

Remove redundant parentheses wrapping, and use CamelCase naming while at it.

Relates to:

- https://github.com/orgs/ipfs/projects/12#card-58209321