### PR TITLE
fix: unsafe pointer passing

### DIFF
--- a/alloc.go
+++ b/alloc.go
@@ -1,0 +1,19 @@
+package openssl
+
+// #include "shim.h"
+import "C"
+
+import (
+	"unsafe"
+
+	"github.com/mattn/go-pointer"
+)
+
+//export go_ssl_crypto_ex_free
+func go_ssl_crypto_ex_free(
+	parent *C.void, ptr unsafe.Pointer,
+	cryptoData *C.CRYPTO_EX_DATA, idx C.int,
+	argl C.long, argp *C.void,
+) {
+	pointer.Unref(ptr)
+}

--- a/conn.go
+++ b/conn.go
@@ -28,6 +28,7 @@ import (
 	"unsafe"
 
 	"github.com/libp2p/go-openssl/utils"
+	"github.com/mattn/go-pointer"
 )
 
 var (
@@ -137,7 +138,7 @@ func newConn(conn net.Conn, ctx *Ctx) (*Conn, error) {
 	C.SSL_set_bio(ssl, into_ssl_cbio, from_ssl_cbio)
 
 	s := &SSL{ssl: ssl}
-	C.SSL_set_ex_data(s.ssl, get_ssl_idx(), unsafe.Pointer(s))
+	C.SSL_set_ex_data(s.ssl, get_ssl_idx(), pointer.Save(s))
 
 	c := &Conn{
 		SSL: s,

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/libp2p/go-openssl
 
 require (
+	github.com/mattn/go-pointer v0.0.1
 	github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572
 	golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/mattn/go-pointer v0.0.1 h1:n+XhsuGeVO6MEAp7xyEukFINEa+Quek5psIR/ylA6o0=
+github.com/mattn/go-pointer v0.0.1/go.mod h1:2zXcozF6qYGgmsG+SeTZz3oAbFLdD3OWqnUbNvJZAlc=
 github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 h1:RC6RW7j+1+HkWaX/Yh71Ee5ZHaHYt7ZP4sQgUrm6cDU=
 github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572/go.mod h1:w0SWMsp6j9O/dk4/ZpIhL+3CkG8ofA2vuv7k+ltqUMc=
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb h1:fgwFCsaw9buMuxNd6+DQfAuSFqbNiQZpcgJQAgJsK6k=

--- a/shim.c
+++ b/shim.c
@@ -428,7 +428,7 @@ int X_SSL_session_reused(SSL *ssl) {
 }
 
 int X_SSL_new_index() {
-	return SSL_get_ex_new_index(0, NULL, NULL, NULL, NULL);
+	return SSL_get_ex_new_index(0, NULL, NULL, NULL, go_ssl_crypto_ex_free);
 }
 
 int X_SSL_verify_cb(int ok, X509_STORE_CTX* store) {

--- a/tickets.go
+++ b/tickets.go
@@ -20,6 +20,8 @@ import "C"
 import (
 	"os"
 	"unsafe"
+
+	"github.com/mattn/go-pointer"
 )
 
 const (
@@ -127,7 +129,7 @@ func go_ticket_key_cb_thunk(p unsafe.Pointer, s *C.SSL, key_name *C.uchar,
 		}
 	}()
 
-	ctx := (*Ctx)(p)
+	ctx := pointer.Restore(p).(*Ctx)
 	store := ctx.ticket_store
 	if store == nil {
 		// TODO(jeff): should this be an error condition? it doesn't make sense


### PR DESCRIPTION
Use [github.com/mattn/go-pointer](https://github.com/mattn/go-pointer) to save/restore "pointers" across FFI bounderies. Go reserves the right to move pointers, so using `unsafe.Pointer` for this is not safe.