### PR TITLE
ci: add go-test-setup action

### DIFF
--- a/.github/actions/go-test-setup/action.yml
+++ b/.github/actions/go-test-setup/action.yml
@@ -1,0 +1,24 @@
+name: Go Test Setup
+description: Set up the environment for go test
+runs:
+  using: "composite"
+  steps:
+    - name: Common setup
+      shell: bash
+      run: |
+        echo 'CGO_ENABLED=1' >> $GITHUB_ENV
+    - name: Windows setup
+      shell: bash
+      if: ${{ runner.os == 'Windows' }}
+      run: |
+        echo '/c/msys64/mingw64/bin' >> $GITHUB_PATH
+        echo 'PATH_386=/c/msys64/mingw32/bin:${{ env.PATH_386 }}' >> $GITHUB_ENV
+    - name: Linux setup
+      shell: bash
+      if: ${{ runner.os == 'Linux' }}
+      run: |
+        sudo apt-get install gcc-multilib
+        sudo dpkg --add-architecture i386
+        sudo apt-get update
+        sudo apt-get install libssl-dev:i386
+        echo 'CC_FOR_linux_386=i686-w64-mingw32-gcc'

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -13,8 +13,8 @@ jobs:
         go: [ "1.16.x", "1.17.x" ]
     env:
       COVERAGES: ""
-    runs-on: ${{ matrix.os }}-latest
-    name: ${{ matrix.os}} (go ${{ matrix.go }})
+    runs-on: ${{ format('{0}-latest', matrix.os) }}
+    name: ${{ matrix.os }} (go ${{ matrix.go }})
     steps:
       - uses: actions/checkout@v2
         with:
@@ -50,7 +50,9 @@ jobs:
         env:
           GOARCH: 386
         with:
-          run: go test -v ./...
+          run: |
+            export "PATH=${{ env.PATH_386 }}:$PATH"
+            go test -v ./...
       - name: Run tests with race detector
         if: ${{ matrix.os == 'ubuntu' }} # speed things up. Windows and OSX VMs are slow
         uses: protocol/multiple-go-modules@v1.2


### PR DESCRIPTION
Requires https://github.com/protocol/.github/pull/289

This PR ensures `CGO_ENABLED` is set for all the `go test` calls. It puts `mingw64` binaries on `PATH` for Windows builds (with override to `mingw32` for `GOARCH=386` via `PATH_386` var introduced in https://github.com/protocol/.github/pull/289). Finally, it installs `gcc-multilib` and `libssl-dev:i386` on Linux workers, and sets the desired C compiler for 32 bit machines to `i686-w64-mingw32-gcc`.