### PR TITLE
decrease required go version to 1.12

### DIFF
--- a/alloc.go
+++ b/alloc.go
@@ -11,9 +11,9 @@ import (
 
 //export go_ssl_crypto_ex_free
 func go_ssl_crypto_ex_free(
-	parent *C.void, ptr unsafe.Pointer,
+	parent unsafe.Pointer, ptr unsafe.Pointer,
 	cryptoData *C.CRYPTO_EX_DATA, idx C.int,
-	argl C.long, argp *C.void,
+	argl C.long, argp unsafe.Pointer,
 ) {
 	pointer.Unref(ptr)
 }

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,4 @@ require (
 	golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb // indirect
 )
 
-go 1.16
+go 1.12


### PR DESCRIPTION
The error occurs when trying to build the library using go < 1.16:
./alloc.go:14:10: unrecognized Go type _Ctype_void
./alloc.go:16:21: unrecognized Go type _Ctype_void

This is an unnecessary restriction. It can be fixed by replacing
*C.void with unsafe.Pointer (as it is already done for `ptr` argument of
CRYPTO_EX_free[1][2]).

1. https://www.openssl.org/docs/manmaster/man3/SSL_get_ex_new_index.html
2. https://www.openssl.org/docs/man3.0/man3/CRYPTO_EX_free.html

Related to #18

Motivation:

I want to use the library with go 1.13.

Before the fix:

```
$ go version
go version go1.12.17 linux/amd64
$ go test
# github.com/libp2p/go-openssl
./alloc.go:14:10: unrecognized Go type _Ctype_void
./alloc.go:16:21: unrecognized Go type _Ctype_void
./alloc.go:14:10: unrecognized Go type _Ctype_void
./alloc.go:16:21: unrecognized Go type _Ctype_void
FAIL	github.com/libp2p/go-openssl [build failed]
```

After the fix:

```
$ go version
go version go1.12.17 linux/amd64
$ go test .
ok  	github.com/oleg-jukovec/go-openssl	4.333s
```