### PR TITLE
Install mingw toolchain on windows machines for go test

### DIFF
--- a/.github/actions/go-test-setup/action.yml
+++ b/.github/actions/go-test-setup/action.yml
@@ -11,8 +11,7 @@ runs:
       shell: bash
       if: ${{ runner.os == 'Windows' }}
       run: |
-        pacman -S --noconfirm mingw-w64-x86_64-toolchain mingw-w64-x86_64-openssl
-        pacman -S --noconfirm mingw-w64-i686-toolchain mingw-w64-i686-openssl
+        pacman -S --noconfirm mingw-w64-x86_64-toolchain mingw-w64-i686-toolchain
         echo '/c/msys64/mingw64/bin' >> $GITHUB_PATH
         echo 'PATH_386=/c/msys64/mingw32/bin:${{ env.PATH_386 }}' >> $GITHUB_ENV
     - name: Linux setup

--- a/.github/actions/go-test-setup/action.yml
+++ b/.github/actions/go-test-setup/action.yml
@@ -11,6 +11,8 @@ runs:
       shell: bash
       if: ${{ runner.os == 'Windows' }}
       run: |
+        pacman -S --noconfirm mingw-w64-x86_64-pkg-config
+        pacman -S --noconfirm mingw-w64-i686-pkg-config
         echo '/c/msys64/mingw64/bin' >> $GITHUB_PATH
         echo 'PATH_386=/c/msys64/mingw32/bin:${{ env.PATH_386 }}' >> $GITHUB_ENV
     - name: Linux setup

--- a/.github/actions/go-test-setup/action.yml
+++ b/.github/actions/go-test-setup/action.yml
@@ -11,8 +11,8 @@ runs:
       shell: bash
       if: ${{ runner.os == 'Windows' }}
       run: |
-        pacman -S --noconfirm mingw-w64-x86_64-pkg-config mingw-w64-x86_64-openssl
-        pacman -S --noconfirm mingw-w64-i686-pkg-config mingw-w64-i686-openssl
+        pacman -S --noconfirm mingw-w64-x86_64-toolchain mingw-w64-x86_64-openssl
+        pacman -S --noconfirm mingw-w64-i686-toolchain mingw-w64-i686-openssl
         echo '/c/msys64/mingw64/bin' >> $GITHUB_PATH
         echo 'PATH_386=/c/msys64/mingw32/bin:${{ env.PATH_386 }}' >> $GITHUB_ENV
     - name: Linux setup

--- a/.github/actions/go-test-setup/action.yml
+++ b/.github/actions/go-test-setup/action.yml
@@ -11,8 +11,8 @@ runs:
       shell: bash
       if: ${{ runner.os == 'Windows' }}
       run: |
-        pacman -S --noconfirm mingw-w64-x86_64-pkg-config
-        pacman -S --noconfirm mingw-w64-i686-pkg-config
+        pacman -S --noconfirm mingw-w64-x86_64-pkg-config mingw-w64-x86_64-openssl
+        pacman -S --noconfirm mingw-w64-i686-pkg-config mingw-w64-i686-openssl
         echo '/c/msys64/mingw64/bin' >> $GITHUB_PATH
         echo 'PATH_386=/c/msys64/mingw32/bin:${{ env.PATH_386 }}' >> $GITHUB_ENV
     - name: Linux setup


### PR DESCRIPTION
It is no longer installed by default on windows-2022 runners